### PR TITLE
Show the repository name in notification

### DIFF
--- a/src/notifications/implementation.ts
+++ b/src/notifications/implementation.ts
@@ -60,6 +60,7 @@ function showNotification(
     iconUrl: "images/GitHub-Mark-120px-plus.png",
     title: getTitle(pullRequest),
     message: getMessage(pullRequest),
+    contextMessage: getContextMessage(pullRequest),
     ...(supportsRequireInteraction ? { requireInteraction: true } : {})
   });
 }
@@ -84,4 +85,8 @@ function getTitle(pullRequest: EnrichedPullRequest): string {
 
 function getMessage(pullRequest: EnrichedPullRequest): string {
   return pullRequest.title;
+}
+
+function getContextMessage(pullRequest: EnrichedPullRequest): string {
+  return `${pullRequest.repoOwner}/${pullRequest.repoName}`;
 }


### PR DESCRIPTION
Fixes #316.

<img width="429" alt="Screen Shot 2019-08-10 at 1 14 21 pm" src="https://user-images.githubusercontent.com/772570/62816875-eab56b00-bb70-11e9-815b-adafe7ebf3a0.png">
