### PR TITLE
Prevent publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "prmonitor",
+  "private": true,
   "dependencies": {
     "@emotion/core": "^10.0.15",
     "@emotion/styled": "^10.0.15",


### PR DESCRIPTION
It's not an npm package so it doesn't need a name either