### PR TITLE
Fix incorrect approvedByEveryone state

### DIFF
--- a/src/filtering/status.spec.ts
+++ b/src/filtering/status.spec.ts
@@ -216,5 +216,49 @@ describe("pullRequestState", () => {
       mergeable: false,
       approvedByEveryone: true
     });
+
+    expect(
+      pullRequestState(
+        fakePullRequest()
+          .author("fwouts")
+          .reviewRequested(["kevin"])
+          .addReview("kevin", "CHANGES_REQUESTED")
+          .addComment("fwouts")
+          .addReview("kevin", "APPROVED")
+          .addComment("dries")
+          .seenAs("fwouts")
+          .build(),
+        "fwouts"
+      )
+    ).toEqual({
+      kind: "outgoing",
+      draft: false,
+      noReviewers: false,
+      changesRequested: false,
+      mergeable: false,
+      approvedByEveryone: false
+    });
+
+    expect(
+      pullRequestState(
+        fakePullRequest()
+          .author("fwouts")
+          .reviewRequested(["kevin"])
+          .addReview("kevin", "CHANGES_REQUESTED")
+          .addComment("fwouts")
+          .addReview("kevin", "APPROVED")
+          .addReview("dries", "COMMENTED")
+          .seenAs("fwouts")
+          .build(),
+        "fwouts"
+      )
+    ).toEqual({
+      kind: "outgoing",
+      draft: false,
+      noReviewers: false,
+      changesRequested: false,
+      mergeable: false,
+      approvedByEveryone: false
+    });
   });
 });

--- a/src/filtering/status.ts
+++ b/src/filtering/status.ts
@@ -63,7 +63,7 @@ function outgoingPullRequestState(
   // Keep track of the last known state of reviews left by others.
   for (const review of pr.reviews) {
     if (review.authorLogin === currentUserLogin) {
-      continue
+      continue;
     }
     const submittedAt = new Date(review.submittedAt).getTime();
     if (
@@ -86,7 +86,7 @@ function outgoingPullRequestState(
   // Ensure that anyone who commented without leaving a review is counted too.
   for (const comment of pr.comments) {
     if (comment.authorLogin === currentUserLogin) {
-      continue
+      continue;
     }
     if (!stateByUser.has(comment.authorLogin)) {
       stateByUser.set(comment.authorLogin, "COMMENTED");


### PR DESCRIPTION
This could occur when one reviewer had approved, and the other had only left a comment.

Fixes #665.