### PR TITLE
Improve support for draft PRs

### DIFF
--- a/src/components/PullRequestItem.tsx
+++ b/src/components/PullRequestItem.tsx
@@ -4,11 +4,11 @@ import { observer } from "mobx-react-lite";
 import React from "react";
 import { Dropdown } from "react-bootstrap";
 import { EnrichedPullRequest } from "../filtering/enriched-pull-request";
+import { isRunningAsPopup } from "../popup-environment";
 import { PullRequest } from "../storage/loaded-state";
 import { MuteType } from "../storage/mute-configuration";
 import { SmallButton } from "./design/Button";
 import { PullRequestStatus } from "./PullRequestStatus";
-import { isRunningAsPopup } from "../popup-environment";
 
 const PullRequestBox = styled.a`
   display: flex;
@@ -137,6 +137,11 @@ export const PullRequestItem = observer((props: PullRequestItemProps) => {
                 <Dropdown.Item onSelect={createMuteHandler("next-update")}>
                   Mute until next update by author
                 </Dropdown.Item>
+                {props.pullRequest.draft && (
+                  <Dropdown.Item onSelect={createMuteHandler("not-draft")}>
+                    Mute until not draft
+                  </Dropdown.Item>
+                )}
                 <Dropdown.Item onSelect={createMuteHandler("1-hour")}>
                   Mute for 1 hour
                 </Dropdown.Item>

--- a/src/filtering/filters.spec.ts
+++ b/src/filtering/filters.spec.ts
@@ -226,6 +226,35 @@ describe("filters (incoming)", () => {
       )
     ).toEqual([Filter.MUTED]);
   });
+  it("is MUTED when the PR is muted until not draft and the PR is still a draft", () => {
+    const env = buildTestingEnvironment();
+    expect(
+      getFilteredBucket(
+        env,
+        "kevin",
+        {
+          mutedPullRequests: [
+            {
+              repo: {
+                owner: "zenclabs",
+                name: "prmonitor",
+              },
+              number: 1,
+              until: {
+                kind: "not-draft",
+              },
+            },
+          ],
+        },
+        fakePullRequest()
+          .draft()
+          .author("fwouts")
+          .seenAs("kevin")
+          .reviewRequested(["kevin"])
+          .build()
+      )
+    ).toEqual([Filter.MUTED]);
+  });
   it("is MUTED when the PR is muted until a specific time that hasn't been reached yet", () => {
     const env = buildTestingEnvironment();
     env.currentTime = 50;
@@ -446,6 +475,34 @@ describe("filters (incoming)", () => {
           .seenAs("kevin")
           .reviewRequested(["kevin"])
           .addComment("fwouts", 200)
+          .build()
+      )
+    ).toEqual([Filter.INCOMING]);
+  });
+  it("is INCOMING when the PR was muted until not draft and the PR is no longer a draft", () => {
+    const env = buildTestingEnvironment();
+    expect(
+      getFilteredBucket(
+        env,
+        "kevin",
+        {
+          mutedPullRequests: [
+            {
+              repo: {
+                owner: "zenclabs",
+                name: "prmonitor",
+              },
+              number: 1,
+              until: {
+                kind: "not-draft",
+              },
+            },
+          ],
+        },
+        fakePullRequest()
+          .author("fwouts")
+          .seenAs("kevin")
+          .reviewRequested(["kevin"])
           .build()
       )
     ).toEqual([Filter.INCOMING]);

--- a/src/filtering/muted.ts
+++ b/src/filtering/muted.ts
@@ -40,6 +40,8 @@ export function isMuted(
           const updatedSince =
             getLastAuthorUpdateTimestamp(pr) > muted.until.mutedAtTimestamp;
           return updatedSince ? MutedResult.VISIBLE : MutedResult.MUTED;
+        case "not-draft":
+          return pr.draft ? MutedResult.MUTED : MutedResult.VISIBLE;
         case "specific-time":
           return currentTime >= muted.until.unmuteAtTimestamp
             ? MutedResult.VISIBLE

--- a/src/filtering/status.spec.ts
+++ b/src/filtering/status.spec.ts
@@ -14,6 +14,7 @@ describe("pullRequestState", () => {
       )
     ).toEqual({
       kind: "incoming",
+      draft: false,
       newReviewRequested: true,
       newCommit: false,
       authorResponded: false,
@@ -31,6 +32,7 @@ describe("pullRequestState", () => {
       )
     ).toEqual({
       kind: "incoming",
+      draft: false,
       newReviewRequested: false,
       newCommit: false,
       authorResponded: true,
@@ -48,6 +50,7 @@ describe("pullRequestState", () => {
       )
     ).toEqual({
       kind: "incoming",
+      draft: false,
       newReviewRequested: false,
       newCommit: true,
       authorResponded: false,
@@ -66,6 +69,7 @@ describe("pullRequestState", () => {
       )
     ).toEqual({
       kind: "incoming",
+      draft: false,
       newReviewRequested: false,
       newCommit: true,
       authorResponded: true,
@@ -82,6 +86,7 @@ describe("pullRequestState", () => {
       )
     ).toEqual({
       kind: "incoming",
+      draft: false,
       newReviewRequested: false,
       newCommit: false,
       authorResponded: false,
@@ -98,6 +103,7 @@ describe("pullRequestState", () => {
       )
     ).toEqual({
       kind: "incoming",
+      draft: false,
       newReviewRequested: false,
       newCommit: false,
       authorResponded: false,
@@ -116,6 +122,7 @@ describe("pullRequestState", () => {
       )
     ).toEqual({
       kind: "not-involved",
+      draft: false,
     });
   });
 

--- a/src/filtering/status.ts
+++ b/src/filtering/status.ts
@@ -19,6 +19,7 @@ export function pullRequestState(
   if (!pr.reviewRequested && !userPreviouslyReviewed(pr, currentUserLogin)) {
     return {
       kind: "not-involved",
+      draft: pr.draft === true,
     };
   }
   return incomingPullRequestState(pr, currentUserLogin);
@@ -39,6 +40,7 @@ function incomingPullRequestState(
   const hasReviewed = lastReviewOrCommentFromCurrentUser > 0;
   return {
     kind: "incoming",
+    draft: pr.draft === true,
     newReviewRequested: !hasReviewed,
     authorResponded: hasReviewed && hasNewCommentByAuthor,
     newCommit: hasReviewed && hasNewCommit,
@@ -121,6 +123,11 @@ export interface IncomingState {
   kind: "incoming";
 
   /**
+   * True if the PR is a draft.
+   */
+  draft: boolean;
+
+  /**
    * True if a review has been requested from the user, but they haven't
    * submitted any review or comments on the PR yet.
    */
@@ -145,6 +152,11 @@ export interface IncomingState {
  */
 export interface NotInvolvedState {
   kind: "not-involved";
+
+  /**
+   * True if the PR is a draft.
+   */
+  draft: boolean;
 }
 
 /**

--- a/src/storage/mute-configuration.ts
+++ b/src/storage/mute-configuration.ts
@@ -52,6 +52,14 @@ export function addMute(
         },
       });
       break;
+    case "not-draft":
+      muteConfiguration.mutedPullRequests.push({
+        ...pullRequest,
+        until: {
+          kind: "not-draft",
+        },
+      });
+      break;
     case "1-hour":
       muteConfiguration.mutedPullRequests.push({
         ...pullRequest,
@@ -146,7 +154,13 @@ export function removeRepositoryMute(
   };
 }
 
-export type MuteType = "next-update" | "1-hour" | "forever" | "repo" | "owner";
+export type MuteType =
+  | "next-update"
+  | "1-hour"
+  | "not-draft"
+  | "forever"
+  | "repo"
+  | "owner";
 
 export interface MutedPullRequest {
   repo: {
@@ -159,6 +173,7 @@ export interface MutedPullRequest {
 
 export type MutedUntil =
   | MutedUntilNextUpdateByAuthor
+  | MutedUntilNotDraft
   | MutedUntilSpecificTime
   | MutedForever;
 
@@ -171,6 +186,10 @@ export interface MutedUntilNextUpdateByAuthor {
    * Any update by the author after this timestamp will make the PR re-appear.
    */
   mutedAtTimestamp: number;
+}
+
+export interface MutedUntilNotDraft {
+  kind: "not-draft";
 }
 
 export interface MutedUntilSpecificTime {


### PR DESCRIPTION
This addresses two separate feature requests for draft PRs:
- Always show the "Draft" badge on PRs, not just for your own PRs.
- Allow "Mute until draft".

Fixes #398.