### PR TITLE
Add a new option "Mute until next comment by author"

### DIFF
--- a/src/components/PullRequestItem.tsx
+++ b/src/components/PullRequestItem.tsx
@@ -134,6 +134,11 @@ export const PullRequestItem = observer((props: PullRequestItemProps) => {
                 <FontAwesomeIcon icon="bell-slash" />
               </Dropdown.Toggle>
               <Dropdown.Menu>
+                <Dropdown.Item
+                  onSelect={createMuteHandler("next-comment-by-author")}
+                >
+                  Mute until next comment by author
+                </Dropdown.Item>
                 <Dropdown.Item onSelect={createMuteHandler("next-update")}>
                   Mute until next update by author
                 </Dropdown.Item>

--- a/src/filtering/filters.spec.ts
+++ b/src/filtering/filters.spec.ts
@@ -195,7 +195,7 @@ describe("filters (incoming)", () => {
       )
     ).toEqual([Filter.INCOMING]);
   });
-  it("is MUTED when the PR is muted until next update and the author did not add new comments or reviews to", () => {
+  it("is MUTED when the PR is muted until next update and the author did not add new comments or reviews", () => {
     const env = buildTestingEnvironment();
     expect(
       getFilteredBucket(
@@ -222,6 +222,36 @@ describe("filters (incoming)", () => {
           .reviewRequested(["kevin"])
           // Another user posted a review after we muted.
           .addReview("dries", "CHANGES_REQUESTED", 200)
+          .build()
+      )
+    ).toEqual([Filter.MUTED]);
+  });
+  it("is MUTED when the PR is muted until next comment and the author added commits but did not add new comments or reviews", () => {
+    const env = buildTestingEnvironment();
+    expect(
+      getFilteredBucket(
+        env,
+        "kevin",
+        {
+          mutedPullRequests: [
+            {
+              repo: {
+                owner: "zenclabs",
+                name: "prmonitor",
+              },
+              number: 1,
+              until: {
+                kind: "next-comment-by-author",
+                mutedAtTimestamp: 100,
+              },
+            },
+          ],
+        },
+        fakePullRequest()
+          .author("fwouts")
+          .seenAs("kevin")
+          .reviewRequested(["kevin"])
+          .addCommit(300)
           .build()
       )
     ).toEqual([Filter.MUTED]);
@@ -448,7 +478,7 @@ describe("filters (incoming)", () => {
       )
     ).toEqual([Filter.IGNORED]);
   });
-  it("is INCOMING when the PR was muted but the author added comments since muting", () => {
+  it("is INCOMING when the PR was muted until next update but the author added comments since muting", () => {
     const env = buildTestingEnvironment();
     expect(
       getFilteredBucket(
@@ -464,6 +494,68 @@ describe("filters (incoming)", () => {
               number: 1,
               until: {
                 kind: "next-update",
+                mutedAtTimestamp: 100,
+              },
+            },
+          ],
+        },
+        fakePullRequest()
+          .ref("zenclabs", "prmonitor", 1)
+          .author("fwouts")
+          .seenAs("kevin")
+          .reviewRequested(["kevin"])
+          .addComment("fwouts", 200)
+          .build()
+      )
+    ).toEqual([Filter.INCOMING]);
+  });
+  it("is INCOMING when the PR was muted until next update but the author added commits since muting", () => {
+    const env = buildTestingEnvironment();
+    expect(
+      getFilteredBucket(
+        env,
+        "kevin",
+        {
+          mutedPullRequests: [
+            {
+              repo: {
+                owner: "zenclabs",
+                name: "prmonitor",
+              },
+              number: 1,
+              until: {
+                kind: "next-update",
+                mutedAtTimestamp: 100,
+              },
+            },
+          ],
+        },
+        fakePullRequest()
+          .ref("zenclabs", "prmonitor", 1)
+          .author("fwouts")
+          .seenAs("kevin")
+          .reviewRequested(["kevin"])
+          .addCommit(200)
+          .build()
+      )
+    ).toEqual([Filter.INCOMING]);
+  });
+  it("is INCOMING when the PR was muted until next comment but the author added comments since muting", () => {
+    const env = buildTestingEnvironment();
+    expect(
+      getFilteredBucket(
+        env,
+        "kevin",
+        {
+          mutedPullRequests: [
+            {
+              repo: {
+                owner: "zenclabs",
+                name: "prmonitor",
+              },
+              number: 1,
+              until: {
+                kind: "next-comment-by-author",
                 mutedAtTimestamp: 100,
               },
             },

--- a/src/filtering/muted.ts
+++ b/src/filtering/muted.ts
@@ -1,7 +1,10 @@
 import { Environment } from "../environment/api";
 import { PullRequest } from "../storage/loaded-state";
 import { MuteConfiguration } from "../storage/mute-configuration";
-import { getLastAuthorUpdateTimestamp } from "./timestamps";
+import {
+  getLastAuthorCommentTimestamp,
+  getLastAuthorUpdateTimestamp,
+} from "./timestamps";
 
 /**
  * Returns whether the pull request is muted.
@@ -40,6 +43,10 @@ export function isMuted(
           const updatedSince =
             getLastAuthorUpdateTimestamp(pr) > muted.until.mutedAtTimestamp;
           return updatedSince ? MutedResult.VISIBLE : MutedResult.MUTED;
+        case "next-comment-by-author":
+          const commentedSince =
+            getLastAuthorCommentTimestamp(pr) > muted.until.mutedAtTimestamp;
+          return commentedSince ? MutedResult.VISIBLE : MutedResult.MUTED;
         case "not-draft":
           return pr.draft ? MutedResult.MUTED : MutedResult.VISIBLE;
         case "specific-time":

--- a/src/storage/mute-configuration.ts
+++ b/src/storage/mute-configuration.ts
@@ -43,6 +43,15 @@ export function addMute(
   };
   // Add the new mute.
   switch (muteType) {
+    case "next-comment-by-author":
+      muteConfiguration.mutedPullRequests.push({
+        ...pullRequest,
+        until: {
+          kind: "next-comment-by-author",
+          mutedAtTimestamp: env.getCurrentTime(),
+        },
+      });
+      break;
     case "next-update":
       muteConfiguration.mutedPullRequests.push({
         ...pullRequest,
@@ -156,6 +165,7 @@ export function removeRepositoryMute(
 
 export type MuteType =
   | "next-update"
+  | "next-comment-by-author"
   | "1-hour"
   | "not-draft"
   | "forever"
@@ -173,6 +183,7 @@ export interface MutedPullRequest {
 
 export type MutedUntil =
   | MutedUntilNextUpdateByAuthor
+  | MutedUntilNextCommentByAuthor
   | MutedUntilNotDraft
   | MutedUntilSpecificTime
   | MutedForever;
@@ -183,7 +194,19 @@ export interface MutedUntilNextUpdateByAuthor {
   /**
    * The timestamp at which the PR was muted.
    *
-   * Any update by the author after this timestamp will make the PR re-appear.
+   * Any update (commit or comment by the author) after this timestamp will make
+   * the PR re-appear.
+   */
+  mutedAtTimestamp: number;
+}
+
+export interface MutedUntilNextCommentByAuthor {
+  kind: "next-comment-by-author";
+
+  /**
+   * The timestamp at which the PR was muted.
+   *
+   * Any comment by the author after this timestamp will make the PR re-appear.
    */
   mutedAtTimestamp: number;
 }


### PR DESCRIPTION
This is a variant of "Mute until next update" that ignores new commits. See #772.