### PR TITLE
Add option for filtering only directly-requested PRs

### DIFF
--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -59,7 +59,10 @@ export const Popup = observer((props: PopupProps) => {
   };
 
   const onChangeWhitelistedTeams = (teamsText: string) => {
-    const teams = teamsText.split(",").map((s) => s.trim()).filter((s) => s.length);
+    const teams = teamsText
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length);
     props.core.onChangeWhitelistedTeamsSetting(teams);
   };
 

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -54,6 +54,15 @@ export const Popup = observer((props: PopupProps) => {
     props.core.toggleNewCommitsNotificationSetting();
   };
 
+  const onToggleOnlyDirectRequests = () => {
+    props.core.toggleOnlyDirectRequestsSetting();
+  };
+
+  const onChangeWhitelistedTeams = (teamsText: string) => {
+    const teams = teamsText.split(",").map((s) => s.trim());
+    props.core.onChangeWhitelistedTeamsSetting(teams);
+  };
+
   if (props.core.overallStatus !== "loaded") {
     return <Loader />;
   }
@@ -169,7 +178,23 @@ export const Popup = observer((props: PopupProps) => {
                   ? !props.core.muteConfiguration.ignoreNewCommits
                   : null
               }
+              onlyDirectRequestsToggled={
+                state.currentFilter === Filter.INCOMING
+                  ? !!props.core.muteConfiguration.onlyDirectRequests
+                  : null
+              }
+              whitelistedTeams={
+                state.currentFilter === Filter.INCOMING
+                  ? props.core.muteConfiguration.whitelistedTeams || []
+                  : []
+              }
+              userLogin={
+                (props.core.loadedState && props.core.loadedState.userLogin) ||
+                undefined
+              }
               onToggleNewCommitsNotification={onToggleNewCommitsNotification}
+              onToggleOnlyDirectRequests={onToggleOnlyDirectRequests}
+              onChangeWhitelistedTeams={onChangeWhitelistedTeams}
               onOpenAll={onOpenAll}
               onOpen={onOpen}
               onMute={onMute}

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -59,7 +59,7 @@ export const Popup = observer((props: PopupProps) => {
   };
 
   const onChangeWhitelistedTeams = (teamsText: string) => {
-    const teams = teamsText.split(",").map((s) => s.trim());
+    const teams = teamsText.split(",").map((s) => s.trim()).filter((s) => s.length);
     props.core.onChangeWhitelistedTeamsSetting(teams);
   };
 

--- a/src/components/PullRequestList.tsx
+++ b/src/components/PullRequestList.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { observer } from "mobx-react-lite";
-import React from "react";
+import React, { useRef, useState } from "react";
+import { Button } from "react-bootstrap";
 import { EnrichedPullRequest } from "../filtering/enriched-pull-request";
 import { PullRequest } from "../storage/loaded-state";
 import { MuteType } from "../storage/mute-configuration";
@@ -28,6 +29,28 @@ const NewCommitsCheckbox = styled.input`
   margin-right: 8px;
 `;
 
+const OnlyDirectRequestsCheckbox = styled.input`
+  margin-right: 8px;
+`;
+
+const OnlyDirectRequestsToggle = styled.label`
+  padding: 8px;
+  margin: 0;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const WhitelistedTeamsInput = styled.input`
+  flex-grow: 1;
+  padding: 4px 8px;
+  margin-right: 8px;
+
+  &:focus {
+    outline-color: #2ee59d;
+  }
+`;
+
 const OpenAllParagraph = styled(Paragraph)`
   text-align: center;
   color: #777;
@@ -38,47 +61,107 @@ export interface PullRequestListProps {
   emptyMessage: string;
   mutingConfiguration: "allow-muting" | "allow-unmuting" | "none";
   newCommitsNotificationToggled: boolean | null;
+  onlyDirectRequestsToggled: boolean | null;
+  whitelistedTeams: string[];
+  userLogin?: string;
   onToggleNewCommitsNotification?(): void;
+  onToggleOnlyDirectRequests?(): void;
+  onChangeWhitelistedTeams?: (text: string) => void;
   onOpenAll(): void;
   onOpen(pullRequestUrl: string): void;
   onMute(pullRequest: PullRequest, muteType: MuteType): void;
   onUnmute(pullRequest: PullRequest): void;
 }
 
-export const PullRequestList = observer((props: PullRequestListProps) => (
-  <List>
-    {props.newCommitsNotificationToggled !== null && (
-      <NewCommitsToggle>
-        <NewCommitsCheckbox
-          type="checkbox"
-          checked={props.newCommitsNotificationToggled}
-          onChange={props.onToggleNewCommitsNotification}
-        />
-        Notify me of new commits
-      </NewCommitsToggle>
-    )}
-    {props.pullRequests === null ? (
-      <Loader />
-    ) : props.pullRequests.length === 0 ? (
-      <Paragraph>{props.emptyMessage}</Paragraph>
-    ) : (
-      <>
-        {props.pullRequests.map((pullRequest) => (
-          <PullRequestItem
-            key={pullRequest.nodeId}
-            pullRequest={pullRequest}
-            mutingConfiguration={props.mutingConfiguration}
-            onOpen={props.onOpen}
-            onMute={props.onMute}
-            onUnmute={props.onUnmute}
+export const PullRequestList = observer((props: PullRequestListProps) => {
+  const defaultWhitelistedTeams = props.whitelistedTeams.join(", ");
+  const [whitelistedTeams, setWhitelistedTeams] = useState(
+    defaultWhitelistedTeams
+  );
+  const inputRef = useRef<HTMLInputElement>(null);
+  const handleWhitelistedTeamsChange = (evt: any) => {
+    evt.preventDefault();
+    if (!inputRef.current) {
+      return;
+    }
+
+    setWhitelistedTeams(inputRef.current.value);
+  };
+  const handleApplyWhitelistedTeamsChange = (evt: any) => {
+    evt.preventDefault();
+    props.onChangeWhitelistedTeams &&
+      props.onChangeWhitelistedTeams(whitelistedTeams);
+  };
+  return (
+    <List>
+      {props.onlyDirectRequestsToggled !== null && (
+        <OnlyDirectRequestsToggle>
+          <OnlyDirectRequestsCheckbox
+            type="checkbox"
+            checked={props.onlyDirectRequestsToggled}
+            onChange={props.onToggleOnlyDirectRequests}
           />
-        ))}
-        {props.pullRequests.length > 1 && (
-          <OpenAllParagraph>
-            <Link onClick={props.onOpenAll}>Open them all</Link>
-          </OpenAllParagraph>
-        )}
-      </>
-    )}
-  </List>
-));
+          <div>
+            Only directly requested
+            {props.userLogin && (
+              <span>
+                {" "}
+                (<b>@{props.userLogin}</b>){" "}
+              </span>
+            )}
+            and whitelisted teams
+            {props.onlyDirectRequestsToggled && props.onChangeWhitelistedTeams && (
+              <div>
+                <WhitelistedTeamsInput
+                  ref={inputRef}
+                  placeholder="team1, team2"
+                  value={whitelistedTeams}
+                  onInput={handleWhitelistedTeamsChange}
+                ></WhitelistedTeamsInput>
+                <Button
+                  disabled={whitelistedTeams === defaultWhitelistedTeams}
+                  onClick={handleApplyWhitelistedTeamsChange}
+                >
+                  Apply
+                </Button>
+              </div>
+            )}
+          </div>
+        </OnlyDirectRequestsToggle>
+      )}
+      {props.newCommitsNotificationToggled !== null && (
+        <NewCommitsToggle>
+          <NewCommitsCheckbox
+            type="checkbox"
+            checked={props.newCommitsNotificationToggled}
+            onChange={props.onToggleNewCommitsNotification}
+          />
+          Notify me of new commits
+        </NewCommitsToggle>
+      )}
+      {props.pullRequests === null ? (
+        <Loader />
+      ) : props.pullRequests.length === 0 ? (
+        <Paragraph>{props.emptyMessage}</Paragraph>
+      ) : (
+        <>
+          {props.pullRequests.map((pullRequest) => (
+            <PullRequestItem
+              key={pullRequest.nodeId}
+              pullRequest={pullRequest}
+              mutingConfiguration={props.mutingConfiguration}
+              onOpen={props.onOpen}
+              onMute={props.onMute}
+              onUnmute={props.onUnmute}
+            />
+          ))}
+          {props.pullRequests.length > 1 && (
+            <OpenAllParagraph>
+              <Link onClick={props.onOpenAll}>Open them all</Link>
+            </OpenAllParagraph>
+          )}
+        </>
+      )}
+    </List>
+  );
+});

--- a/src/components/PullRequestList.tsx
+++ b/src/components/PullRequestList.tsx
@@ -1,11 +1,11 @@
 import styled from "@emotion/styled";
 import { observer } from "mobx-react-lite";
 import React, { useRef, useState } from "react";
-import { Button } from "react-bootstrap";
 import { EnrichedPullRequest } from "../filtering/enriched-pull-request";
 import { PullRequest } from "../storage/loaded-state";
 import { MuteType } from "../storage/mute-configuration";
 import { Link } from "./design/Link";
+import { LargeButton } from "./design/Button";
 import { Paragraph } from "./design/Paragraph";
 import { Loader } from "./Loader";
 import { PullRequestItem } from "./PullRequestItem";
@@ -118,12 +118,12 @@ export const PullRequestList = observer((props: PullRequestListProps) => {
                   value={whitelistedTeams}
                   onInput={handleWhitelistedTeamsChange}
                 ></WhitelistedTeamsInput>
-                <Button
+                <LargeButton
                   disabled={whitelistedTeams === defaultWhitelistedTeams}
                   onClick={handleApplyWhitelistedTeamsChange}
                 >
                   Apply
-                </Button>
+                </LargeButton>
               </div>
             )}
           </div>

--- a/src/components/design/Button.tsx
+++ b/src/components/design/Button.tsx
@@ -12,10 +12,14 @@ const Button = styled.button`
   outline: none !important;
   font-size: 1em;
 
-  &:hover {
+  &:hover:enabled {
     background-color: #2ee59d;
     box-shadow: 0px 5px 10px rgba(46, 229, 157, 0.4);
     color: #fff;
+  }
+
+  &:disabled {
+    color: #999;
   }
 `;
 

--- a/src/filtering/filters.spec.ts
+++ b/src/filtering/filters.spec.ts
@@ -1,8 +1,18 @@
 import { buildTestingEnvironment } from "../environment/testing/fake";
-import { NOTHING_MUTED } from "../storage/mute-configuration";
+import {
+  MuteConfiguration,
+  NOTHING_MUTED,
+} from "../storage/mute-configuration";
 import { fakePullRequest } from "../testing/fake-pr";
 import { Filter } from "./filters";
 import { getFilteredBucket } from "./testing";
+
+const DIRECT_REQUEST_UNMUTED: MuteConfiguration = {
+  ...NOTHING_MUTED,
+
+  onlyDirectRequests: true,
+  whitelistedTeams: ["whitelisted-team"],
+};
 
 describe("filters (incoming)", () => {
   it("is MINE for the user's own PRs", () => {
@@ -46,6 +56,61 @@ describe("filters (incoming)", () => {
           .author("fwouts")
           .seenAs("kevin")
           .reviewRequested(["kevin"])
+          .build()
+      )
+    ).toEqual([Filter.INCOMING]);
+  });
+  it("is INCOMING when the user is in a reviewer team and hasn't reviewed or commented", () => {
+    const env = buildTestingEnvironment();
+    expect(
+      getFilteredBucket(
+        env,
+        "kevin",
+        NOTHING_MUTED,
+        fakePullRequest()
+          .author("fwouts")
+          .seenAs("kevin")
+          .teams({
+            team: ["kevin"],
+          })
+          .reviewRequested([], ["team"])
+          .build()
+      )
+    ).toEqual([Filter.INCOMING]);
+  });
+  it("is INCOMING when the user is in a reviewer team, but only wants whitelisted teams", () => {
+    const env = buildTestingEnvironment();
+    expect(
+      getFilteredBucket(
+        env,
+        "kevin",
+        DIRECT_REQUEST_UNMUTED,
+        fakePullRequest()
+          .author("fwouts")
+          .seenAs("kevin")
+          .teams({
+            team: ["kevin"],
+          })
+          .reviewRequested([], ["team"])
+          .build()
+      )
+    ).toEqual([]);
+  });
+  it("is INCOMING when the user is in a reviewer team, but only wants whitelisted teams", () => {
+    const env = buildTestingEnvironment();
+    expect(
+      getFilteredBucket(
+        env,
+        "kevin",
+        DIRECT_REQUEST_UNMUTED,
+        fakePullRequest()
+          .author("fwouts")
+          .seenAs("kevin")
+          .teams({
+            team: ["kevin"],
+            "whitelisted-team": ["kevin"],
+          })
+          .reviewRequested([], ["whitelisted-team"])
           .build()
       )
     ).toEqual([Filter.INCOMING]);
@@ -195,6 +260,56 @@ describe("filters (incoming)", () => {
       )
     ).toEqual([Filter.INCOMING]);
   });
+  it("is still INCOMING when there are pending review comments, and reviewer in reviewer team", () => {
+    const env = buildTestingEnvironment();
+    expect(
+      getFilteredBucket(
+        env,
+        "kevin",
+        NOTHING_MUTED,
+        fakePullRequest()
+          .author("fwouts")
+          .seenAs("kevin")
+          .teams({
+            team: ["kevin"],
+          })
+          .reviewRequested([], ["team"])
+          .addReview("kevin", "PENDING")
+          .build()
+      )
+    ).toEqual([Filter.INCOMING]);
+  });
+  it("is MUTED when the PR is muted until next update and the author did not add new comments or reviews", () => {
+    const env = buildTestingEnvironment();
+    expect(
+      getFilteredBucket(
+        env,
+        "kevin",
+        {
+          mutedPullRequests: [
+            {
+              repo: {
+                owner: "zenclabs",
+                name: "prmonitor",
+              },
+              number: 1,
+              until: {
+                kind: "next-update",
+                mutedAtTimestamp: 100,
+              },
+            },
+          ],
+        },
+        fakePullRequest()
+          .author("fwouts")
+          .seenAs("kevin")
+          .reviewRequested(["kevin"])
+          // Another user posted a review after we muted.
+          .addReview("dries", "CHANGES_REQUESTED", 200)
+          .build()
+      )
+    ).toEqual([Filter.MUTED]);
+  });
   it("is MUTED when the PR is muted until next update and the author did not add new comments or reviews", () => {
     const env = buildTestingEnvironment();
     expect(
@@ -250,7 +365,10 @@ describe("filters (incoming)", () => {
         fakePullRequest()
           .author("fwouts")
           .seenAs("kevin")
-          .reviewRequested(["kevin"])
+          .teams({
+            team: ["kevin"],
+          })
+          .reviewRequested([], ["team"])
           .addCommit(300)
           .build()
       )

--- a/src/filtering/filters.spec.ts
+++ b/src/filtering/filters.spec.ts
@@ -78,7 +78,7 @@ describe("filters (incoming)", () => {
       )
     ).toEqual([Filter.INCOMING]);
   });
-  it("is INCOMING when the user is in a reviewer team, but only wants whitelisted teams", () => {
+  it("is NOTHING when the user is in a reviewer team, but only wants whitelisted teams", () => {
     const env = buildTestingEnvironment();
     expect(
       getFilteredBucket(

--- a/src/filtering/filters.spec.ts
+++ b/src/filtering/filters.spec.ts
@@ -279,7 +279,7 @@ describe("filters (incoming)", () => {
       )
     ).toEqual([Filter.INCOMING]);
   });
-  it("is MUTED when the PR is muted until next update and the author did not add new comments or reviews", () => {
+  it("is MUTED when the PR is muted until next update and the author did not add new comments or reviews [reviewer-direct-requested]", () => {
     const env = buildTestingEnvironment();
     expect(
       getFilteredBucket(
@@ -310,38 +310,7 @@ describe("filters (incoming)", () => {
       )
     ).toEqual([Filter.MUTED]);
   });
-  it("is MUTED when the PR is muted until next update and the author did not add new comments or reviews", () => {
-    const env = buildTestingEnvironment();
-    expect(
-      getFilteredBucket(
-        env,
-        "kevin",
-        {
-          mutedPullRequests: [
-            {
-              repo: {
-                owner: "zenclabs",
-                name: "prmonitor",
-              },
-              number: 1,
-              until: {
-                kind: "next-update",
-                mutedAtTimestamp: 100,
-              },
-            },
-          ],
-        },
-        fakePullRequest()
-          .author("fwouts")
-          .seenAs("kevin")
-          .reviewRequested(["kevin"])
-          // Another user posted a review after we muted.
-          .addReview("dries", "CHANGES_REQUESTED", 200)
-          .build()
-      )
-    ).toEqual([Filter.MUTED]);
-  });
-  it("is MUTED when the PR is muted until next comment and the author added commits but did not add new comments or reviews", () => {
+  it("is MUTED when the PR is muted until next comment and the author added commits but did not add new comments or reviews [reviewer-team-requested]", () => {
     const env = buildTestingEnvironment();
     expect(
       getFilteredBucket(

--- a/src/filtering/filters.ts
+++ b/src/filtering/filters.ts
@@ -49,16 +49,26 @@ export function filterPullRequests(
     ...pr,
   }));
   const ignoreNewCommits = !!muteConfiguration.ignoreNewCommits;
+  const onlyDirectRequests = !!muteConfiguration.onlyDirectRequests;
+  const whitelistedTeams = muteConfiguration.whitelistedTeams || [];
   return {
     incoming: enrichedPullRequests.filter(
       (pr) =>
-        isReviewRequired(pr.state, ignoreNewCommits) &&
-        isMuted(env, pr, muteConfiguration) === MutedResult.VISIBLE
+        isReviewRequired(
+          pr.state,
+          ignoreNewCommits,
+          onlyDirectRequests,
+          whitelistedTeams
+        ) && isMuted(env, pr, muteConfiguration) === MutedResult.VISIBLE
     ),
     muted: enrichedPullRequests.filter(
       (pr) =>
-        isReviewRequired(pr.state, ignoreNewCommits) &&
-        isMuted(env, pr, muteConfiguration) === MutedResult.MUTED
+        isReviewRequired(
+          pr.state,
+          ignoreNewCommits,
+          onlyDirectRequests,
+          whitelistedTeams
+        ) && isMuted(env, pr, muteConfiguration) === MutedResult.MUTED
     ),
     reviewed: enrichedPullRequests.filter(
       (pr) =>

--- a/src/filtering/status.spec.ts
+++ b/src/filtering/status.spec.ts
@@ -18,6 +18,31 @@ describe("pullRequestState", () => {
       newReviewRequested: true,
       newCommit: false,
       authorResponded: false,
+      directlyAdded: true,
+      teams: [],
+    });
+
+    expect(
+      pullRequestState(
+        fakePullRequest()
+          .author("kevin")
+          .seenAs("fwouts")
+          .teams({
+            team: ["fwouts"],
+            "out-team": ["dries"],
+          })
+          .reviewRequested([], ["team"])
+          .build(),
+        "fwouts"
+      )
+    ).toEqual({
+      kind: "incoming",
+      draft: false,
+      newReviewRequested: true,
+      newCommit: false,
+      authorResponded: false,
+      directlyAdded: false,
+      teams: ["team"],
     });
 
     expect(
@@ -36,6 +61,8 @@ describe("pullRequestState", () => {
       newReviewRequested: false,
       newCommit: false,
       authorResponded: true,
+      directlyAdded: false,
+      teams: [],
     });
 
     expect(
@@ -54,6 +81,8 @@ describe("pullRequestState", () => {
       newReviewRequested: false,
       newCommit: true,
       authorResponded: false,
+      directlyAdded: false,
+      teams: [],
     });
 
     expect(
@@ -73,6 +102,8 @@ describe("pullRequestState", () => {
       newReviewRequested: false,
       newCommit: true,
       authorResponded: true,
+      directlyAdded: false,
+      teams: [],
     });
 
     expect(
@@ -90,6 +121,8 @@ describe("pullRequestState", () => {
       newReviewRequested: false,
       newCommit: false,
       authorResponded: false,
+      directlyAdded: false,
+      teams: [],
     });
 
     expect(
@@ -107,6 +140,8 @@ describe("pullRequestState", () => {
       newReviewRequested: false,
       newCommit: false,
       authorResponded: false,
+      directlyAdded: false,
+      teams: [],
     });
   });
 
@@ -117,6 +152,24 @@ describe("pullRequestState", () => {
           .author("kevin")
           .seenAs("fwouts")
           .reviewRequested(["dries"])
+          .build(),
+        "fwouts"
+      )
+    ).toEqual({
+      kind: "not-involved",
+      draft: false,
+    });
+
+    expect(
+      pullRequestState(
+        fakePullRequest()
+          .author("kevin")
+          .seenAs("fwouts")
+          .teams({
+            team: ["fwouts"],
+            "out-team": ["dries"],
+          })
+          .reviewRequested([], ["out-team"])
           .build(),
         "fwouts"
       )

--- a/src/loading/internal/pull-requests.spec.ts
+++ b/src/loading/internal/pull-requests.spec.ts
@@ -82,6 +82,7 @@ describe("refreshOpenPullRequests", () => {
     githubApi.loadPullRequestDetails.mockReturnValue(
       Promise.resolve(({
         requested_reviewers: [],
+        requested_teams: [],
       } as unknown) as PullsGetResponse)
     );
     githubApi.loadComments.mockReturnValue(Promise.resolve([]));

--- a/src/loading/internal/pull-requests.ts
+++ b/src/loading/internal/pull-requests.ts
@@ -124,6 +124,7 @@ function pullRequestFromResponse(
     requestedReviewers: details.requested_reviewers.map(
       (reviewer) => reviewer.login
     ),
+    requestedTeams: details.requested_teams.map((team) => team.name),
     reviews,
     comments,
     commits,

--- a/src/state/core.ts
+++ b/src/state/core.ts
@@ -155,6 +155,23 @@ export class Core {
     this.updateBadge();
   }
 
+  async toggleOnlyDirectRequestsSetting() {
+    const newOnlyDirectRequests = !this.muteConfiguration.onlyDirectRequests;
+    await this.saveMuteConfiguration({
+      ...this.muteConfiguration,
+      onlyDirectRequests: newOnlyDirectRequests,
+    });
+    this.updateBadge();
+  }
+
+  async onChangeWhitelistedTeamsSetting(teams: string[]) {
+    await this.saveMuteConfiguration({
+      ...this.muteConfiguration,
+      whitelistedTeams: teams,
+    });
+    this.updateBadge();
+  }
+
   @computed
   get filteredPullRequests(): FilteredPullRequests | null {
     const lastCheck = this.loadedState;

--- a/src/storage/loaded-state.ts
+++ b/src/storage/loaded-state.ts
@@ -72,6 +72,7 @@ export interface PullRequest {
    */
   // TODO: Make this required in September 2019.
   requestedReviewers?: string[];
+  requestedTeams?: string[];
   reviews: Review[];
   comments: Comment[];
   commits?: Commit[];

--- a/src/storage/mute-configuration.ts
+++ b/src/storage/mute-configuration.ts
@@ -7,6 +7,8 @@ export const NOTHING_MUTED: MuteConfiguration = {
   mutedPullRequests: [],
   ignored: {},
   ignoreNewCommits: false,
+  onlyDirectRequests: false,
+  whitelistedTeams: [],
 };
 
 export interface MuteConfiguration {
@@ -24,6 +26,10 @@ export interface MuteConfiguration {
   };
 
   ignoreNewCommits?: boolean;
+
+  onlyDirectRequests?: boolean;
+
+  whitelistedTeams?: string[];
 }
 
 export function addMute(

--- a/src/testing/fake-pr.ts
+++ b/src/testing/fake-pr.ts
@@ -22,6 +22,8 @@ class FakePullRequestBuilder {
     number: 1,
   };
   private _reviewerLogins: string[] = [];
+  private _reviewerTeams: string[] = [];
+  private _teamMap: Record<string, string[]> = {};
   private _comments: Comment[] = [];
   private _reviews: Review[] = [];
   private _commits: Commit[] = [];
@@ -57,8 +59,14 @@ class FakePullRequestBuilder {
     return this;
   }
 
-  reviewRequested(logins: string[]) {
+  reviewRequested(logins: string[], teams?: string[]) {
     this._reviewerLogins = logins;
+    this._reviewerTeams = teams || [];
+    return this;
+  }
+
+  teams(teamMap: Record<string, string[]>) {
+    this._teamMap = teamMap;
     return this;
   }
 
@@ -91,6 +99,12 @@ class FakePullRequestBuilder {
   }
 
   build(): PullRequest {
+    const reviewTeamRequested = this._reviewerTeams.some((teamName) => {
+      const members = this._teamMap[teamName] || [];
+      return members.includes(this._seenAs);
+    });
+    const reviewRequested =
+      this._reviewerLogins.includes(this._seenAs) || reviewTeamRequested;
     return {
       author: {
         login: this._author,
@@ -110,8 +124,9 @@ class FakePullRequestBuilder {
       mergeable: this._mergeable,
       updatedAt: "1 June 2019",
       htmlUrl: `http://github.com/${this._ref.repo.owner}/${this._ref.repo.name}/${this._ref.number}`,
-      reviewRequested: this._reviewerLogins.includes(this._seenAs),
+      reviewRequested: reviewRequested,
       requestedReviewers: this._reviewerLogins,
+      requestedTeams: this._reviewerTeams,
       comments: this._comments,
       reviews: this._reviews,
       commits: this._commits,


### PR DESCRIPTION
- Add checkbox for filtering only directly-requested PRs
- Allow including list of whitelisted team names

Screenshot:
Default Off:
![image](https://user-images.githubusercontent.com/373109/125128227-b968bf80-e138-11eb-87c1-fa4d49efecb2.png)

On, with whitelisted team names:
![image](https://user-images.githubusercontent.com/373109/125410532-edbdd380-e3f7-11eb-9ba9-a0512437a7a9.png)

