### PR TITLE
Change default Notify New Commits to off

### DIFF
--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -166,7 +166,7 @@ export const Popup = observer((props: PopupProps) => {
               }
               newCommitsNotificationToggled={
                 state.currentFilter === Filter.INCOMING
-                  ? !props.core.muteConfiguration.ignoreNewCommits
+                  ? !!props.core.muteConfiguration.notifyNewCommits
                   : null
               }
               onToggleNewCommitsNotification={onToggleNewCommitsNotification}

--- a/src/components/PullRequestList.tsx
+++ b/src/components/PullRequestList.tsx
@@ -54,7 +54,7 @@ export const PullRequestList = observer((props: PullRequestListProps) => (
           checked={props.newCommitsNotificationToggled}
           onChange={props.onToggleNewCommitsNotification}
         />
-        Notify me of new commits
+        Include new commits
       </NewCommitsToggle>
     )}
     {props.pullRequests === null ? (

--- a/src/filtering/filters.ts
+++ b/src/filtering/filters.ts
@@ -48,23 +48,23 @@ export function filterPullRequests(
     state: pullRequestState(pr, userLogin),
     ...pr,
   }));
-  const ignoreNewCommits = !!muteConfiguration.ignoreNewCommits;
+  const notifyNewCommits = !!muteConfiguration.notifyNewCommits;
   return {
     incoming: enrichedPullRequests.filter(
       (pr) =>
-        isReviewRequired(pr.state, ignoreNewCommits) &&
+        isReviewRequired(pr.state, notifyNewCommits) &&
         isMuted(env, pr, muteConfiguration) === MutedResult.VISIBLE
     ),
     muted: enrichedPullRequests.filter(
       (pr) =>
-        isReviewRequired(pr.state, ignoreNewCommits) &&
+        isReviewRequired(pr.state, notifyNewCommits) &&
         isMuted(env, pr, muteConfiguration) === MutedResult.MUTED
     ),
     reviewed: enrichedPullRequests.filter(
       (pr) =>
         pr.state.kind === "incoming" &&
         !pr.state.newReviewRequested &&
-        (!pr.state.newCommit || ignoreNewCommits) &&
+        (!pr.state.newCommit || !notifyNewCommits) &&
         !pr.state.authorResponded
     ),
     mine: enrichedPullRequests.filter((pr) => pr.author.login === userLogin),

--- a/src/filtering/status.ts
+++ b/src/filtering/status.ts
@@ -194,12 +194,12 @@ export interface OutgoingState {
 
 export function isReviewRequired(
   state: PullRequestState,
-  ignoreNewCommits: boolean
+  notifyNewCommits: boolean
 ) {
   return (
     state.kind === "incoming" &&
     (state.newReviewRequested ||
       state.authorResponded ||
-      (!ignoreNewCommits && state.newCommit))
+      (notifyNewCommits && state.newCommit))
   );
 }

--- a/src/state/core.ts
+++ b/src/state/core.ts
@@ -150,7 +150,7 @@ export class Core {
   async toggleNewCommitsNotificationSetting() {
     await this.saveMuteConfiguration({
       ...this.muteConfiguration,
-      ignoreNewCommits: !this.muteConfiguration.ignoreNewCommits,
+      notifyNewCommits: !this.muteConfiguration.notifyNewCommits,
     });
     this.updateBadge();
   }

--- a/src/storage/mute-configuration.ts
+++ b/src/storage/mute-configuration.ts
@@ -6,7 +6,7 @@ import { PullRequestReference, RepoReference } from "../github-api/api";
 export const NOTHING_MUTED: MuteConfiguration = {
   mutedPullRequests: [],
   ignored: {},
-  ignoreNewCommits: false,
+  notifyNewCommits: false,
 };
 
 export interface MuteConfiguration {
@@ -23,7 +23,7 @@ export interface MuteConfiguration {
     [owner: string]: IgnoreConfiguration;
   };
 
-  ignoreNewCommits?: boolean;
+  notifyNewCommits?: boolean;
 }
 
 export function addMute(


### PR DESCRIPTION
- Rename option `Notify me of new commits` -> `Include new commits`
- Change default to off, renaming MuteConfiguration state to `notifyNewCommits`
- Will drop old state if people have set one or another
  - Should be easy for someone to just click checkbox if it's a problem

Screenshot:
![image](https://user-images.githubusercontent.com/373109/125415407-5b28c4a6-ccfe-40db-b9f2-ee4f24e095c7.png)
