### PR TITLE
Remove CircleCI from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,56 +1,5 @@
 version: 2.1
 jobs:
-  build:
-    docker:
-      - image: circleci/node
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v3-dependencies-{{ checksum "package.json" }}
-            - v3-dependencies-
-      - run: yarn install --frozen-lockfile
-      - save_cache:
-          paths:
-            - node_modules
-          key: v3-dependencies-{{ checksum "package.json" }}
-      - run: yarn build
-  test:
-    docker:
-      - image: circleci/node
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v3-dependencies-{{ checksum "package.json" }}
-            - v3-dependencies-
-      - run: yarn install --frozen-lockfile
-      - save_cache:
-          paths:
-            - node_modules
-          key: v3-dependencies-{{ checksum "package.json" }}
-      - run: yarn test --passWithNoTests
-  lint:
-    docker:
-      - image: circleci/node
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v3-dependencies-{{ checksum "package.json" }}
-            - v3-dependencies-
-      - run: yarn install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v3-dependencies-{{ checksum "package.json" }}
-      - run:
-          name: Prettier
-          command: |
-            yarn lint:check
   build-release:
     docker:
       - image: circleci/node
@@ -72,11 +21,6 @@ jobs:
       - store_artifacts:
           path: dist/extension.zip
 workflows:
-  build_and_test:
-    jobs:
-      - build
-      - test
-      - lint
   release:
     jobs:
       - build-release:


### PR DESCRIPTION
A separate PR will be made to move the release process from CircleCI to GitHub Actions.