### PR TITLE
Change "Refresh now" text to button for better actionability

### DIFF
--- a/src/components/Status.tsx
+++ b/src/components/Status.tsx
@@ -3,8 +3,8 @@ import { observer } from "mobx-react-lite";
 import moment from "moment";
 import React from "react";
 import { Alert } from "react-bootstrap";
+import { SmallButton } from "./design/Button";
 import { Core } from "../state/core";
-import { Link } from "./design/Link";
 
 export interface StatusProps {
   core: Core;
@@ -25,13 +25,13 @@ export const Status = observer((props: StatusProps) => {
         {props.core.refreshing ? (
           "Refreshing..."
         ) : (
-          <Link
+          <SmallButton
             onClick={() => {
               props.core.triggerBackgroundRefresh();
             }}
           >
-            Refresh now
-          </Link>
+            Refresh
+          </SmallButton>
         )}
       </div>
     );


### PR DESCRIPTION
Add button for Refresh Now
- Change copy to `Refresh`, since it seems to be clickable, and implies now

Screenshot:
![image](https://user-images.githubusercontent.com/373109/127035955-a8a213db-cbee-48e9-ba00-cab0d14a8828.png)
