### PR TITLE
Popup: Fix second monitor refreshing of text boxes on Macs

### DIFF
--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -52,6 +52,24 @@ ReactDOM.render(
         .nav-tabs {
           border-bottom: none;
         }
+
+        /**
+         * Temporary workaround for secondary monitors on MacOS where redraws don't happen
+         * TODO: Remove once Chromium fixes bug.
+         * Ref: https://stackoverflow.com/questions/56500742/why-is-my-google-chrome-extensions-popup-ui-laggy-on-external-monitors-but-not/64113061#64113061
+         * @See https://bugs.chromium.org/p/chromium/issues/detail?id=971701
+         */
+        @keyframes redraw {
+          0% {
+            opacity: 1;
+          }
+          100% {
+            opacity: 0.99;
+          }
+        }
+        html {
+          animation: redraw 1s linear infinite;
+        }
       `}
     />
     <Popup core={core} />

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -29,49 +29,56 @@ const env = buildEnvironment(chromeApiSingleton);
 const core = new Core(env);
 core.load().catch(console.error);
 
+let globalCssTemplates = `
+  @import url("https://fonts.googleapis.com/css?family=Roboto");
+
+  body {
+    background: #f6f8fc;
+    color: #444;
+    margin: 0 auto;
+    padding: 8px;
+    width: 600px;
+    font-family: Roboto, sans-serif;
+    font-size: 14px;
+  }
+
+  a {
+    color: #000;
+  }
+
+  .nav-tabs {
+    border-bottom: none;
+  }
+`;
+
+// Temporary workaround for secondary monitors on MacOS where redraws don't happen
+// TODO: Remove once Chromium fixes bug.
+// Ref: https://stackoverflow.com/questions/56500742/why-is-my-google-chrome-extensions-popup-ui-laggy-on-external-monitors-but-not/64113061#64113061
+// @See https://bugs.chromium.org/p/chromium/issues/detail?id=971701
+const isSecondMonitor =
+  window.screenLeft < 0 ||
+  window.screenTop < 0 ||
+  window.screenLeft > window.screen.width ||
+  window.screenTop > window.screen.height;
+if (isSecondMonitor) {
+  globalCssTemplates += `
+    @keyframes redraw {
+      0% {
+        opacity: 1;
+      }
+      100% {
+        opacity: 0.99;
+      }
+    }
+    html {
+      animation: redraw 1s linear infinite;
+    }
+  `;
+}
+
 ReactDOM.render(
   <>
-    <Global
-      styles={css`
-        @import url("https://fonts.googleapis.com/css?family=Roboto");
-
-        body {
-          background: #f6f8fc;
-          color: #444;
-          margin: 0 auto;
-          padding: 8px;
-          width: 600px;
-          font-family: Roboto, sans-serif;
-          font-size: 14px;
-        }
-
-        a {
-          color: #000;
-        }
-
-        .nav-tabs {
-          border-bottom: none;
-        }
-
-        /**
-         * Temporary workaround for secondary monitors on MacOS where redraws don't happen
-         * TODO: Remove once Chromium fixes bug.
-         * Ref: https://stackoverflow.com/questions/56500742/why-is-my-google-chrome-extensions-popup-ui-laggy-on-external-monitors-but-not/64113061#64113061
-         * @See https://bugs.chromium.org/p/chromium/issues/detail?id=971701
-         */
-        @keyframes redraw {
-          0% {
-            opacity: 1;
-          }
-          100% {
-            opacity: 0.99;
-          }
-        }
-        html {
-          animation: redraw 1s linear infinite;
-        }
-      `}
-    />
+    <Global styles={css(globalCssTemplates)} />
     <Popup core={core} />
   </>,
   document.getElementById("root")


### PR DESCRIPTION
## Description
Force periodic redraw of Popup on secondary monitors, as workaround for Chromium on Mac bug

## Ref:
Chromium Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=971701
Workaround Ref: https://stackoverflow.com/questions/56500742/why-is-my-google-chrome-extensions-popup-ui-laggy-on-external-monitors-but-not/64113061#64113061

## Screenshot
![image](https://user-images.githubusercontent.com/373109/129316054-f5c1c2ff-1171-47a3-ace7-445177f240b4.png)

## Testing
Open extension on Mac external monitor
- Open `Update Token` and click on text box, and see blinking cursor