### PR TITLE
#1045 - handle secondary rate limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.15",
-    "@octokit/plugin-throttling": "^3.5.1",
+    "@octokit/plugin-throttling": "^3.6.2",
     "@octokit/rest": "^18.9.0",
     "@types/lodash": "^4.14.172",
     "assert-never": "^1.2.1",

--- a/src/github-api/implementation.ts
+++ b/src/github-api/implementation.ts
@@ -32,13 +32,13 @@ export function buildGitHubApi(token: string): GitHubApi {
         }
         return false;
       },
-      onAbuseLimit: (
+      onSecondaryRateLimit: (
         _retryAfterSeconds: number,
         options: ThrottlingOptions
       ) => {
         // Does not retry, only logs a warning.
         console.warn(
-          `Abuse detected for request ${options.method} ${options.url}`
+          `Secondary Rate Limit detected for request ${options.method} ${options.url}`
         );
         return false;
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1376,10 +1376,10 @@
     "@octokit/types" "^6.24.0"
     deprecation "^2.3.1"
 
-"@octokit/plugin-throttling@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-throttling/-/plugin-throttling-3.5.1.tgz#889e80e7f3464a18c768337369498d2d47c0b643"
-  integrity sha512-d2jh3/RZo98DRw2J0jFxhKz7nrTGalGdkfRtxM+pI5k1wRb4BKBjiuE9cuZnhZyj+zLC1EcIptj7K+28LJZ3eA==
+"@octokit/plugin-throttling@^3.6.2":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-throttling/-/plugin-throttling-3.7.0.tgz#a35cd05de22b2ef13fde45390d983ff8365b9a9e"
+  integrity sha512-qrKT1Yl/KuwGSC6/oHpLBot3ooC9rq0/ryDYBCpkRtoj+R8T47xTMDT6Tk2CxWopFota/8Pi/2SqArqwC0JPow==
   dependencies:
     "@octokit/types" "^6.0.1"
     bottleneck "^2.15.3"


### PR DESCRIPTION
## Background
Github has changed their error message for "abuse" limits to "secondary rate" limits. The onAbuseLimit handler in the currently-used version of octokit/plugin-throttling does not handle the updated error message.

See #1045 

## Changes
* Increases version of octokit/plugin-throttling from ^3.5.1 to ^3.6.2 (yarn installs 3.7.0)
* Replace deprecated `onAbuseLimit` handler with `onSecondaryRateLimit`


## Testing
Verified locally by refreshing token to provoke Secondary Rate Limit, and viewing error message in Dev Console:

<img width="873" alt="image" src="https://user-images.githubusercontent.com/108751259/182647182-da257adb-6c7f-4432-98df-29e65944d0cf.png">

