### PR TITLE
feat: Support browser-specific manifest generation for Chrome and Firefox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,6 @@ jobs:
       - run: yarn install --frozen-lockfile
       - name: yarn build and test
         run: |
-          yarn build
+          yarn build:all
           yarn test
           yarn lint:check

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # production
 /dist
+/dist-*
 
 # misc
 .DS_Store

--- a/manifest.template.json
+++ b/manifest.template.json
@@ -6,7 +6,8 @@
   "permissions": ["alarms", "notifications", "storage"],
   "optional_permissions": ["tabs"],
   "background": {
-    "service_worker": "background.js",
+    "__chrome__service_worker": "background.js",
+    "__firefox__scripts": ["background.js"],
     "type": "module"
   },
   "action": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,12 @@
   "scripts": {
     "start": "webpack serve",
     "watch": "tsc --noEmit --watch",
-    "build": "rm -rf dist; webpack --mode production",
+    "build:chrome-mv3": "rm -rf dist-chrome-mv3; BROWSER=chrome webpack --mode production",
+    "build:firefox-mv3": "rm -rf dist-firefox-mv3; BROWSER=firefox webpack --mode production",
+    "build:all": "npm run build:chrome-mv3 && npm run build:firefox-mv3",
+    "zip:chrome-mv3": "cd dist-chrome-mv3 && zip -r ../dist-chrome-mv3.zip .",
+    "zip:firefox-mv3": "cd dist-firefox-mv3 && zip -r ../dist-firefox-mv3.zip .",
+    "zip:all": "npm run zip:chrome-mv3 && npm run zip:firefox-mv3",
     "test": "jest",
     "lint:check": "eslint \"src/**/*.ts\" \"src/**/*.tsx\"",
     "lint:fix": "eslint --fix \"src/**/*.ts\" \"src/**/*.tsx\""

--- a/scripts/transform-manifest.js
+++ b/scripts/transform-manifest.js
@@ -1,0 +1,64 @@
+/**
+ * Transforms the manifest.json file for the given browser.
+ * @param {string} browser - The browser to transform the manifest.json for.
+ * @returns {function} - A function that transforms the manifest.json file.
+ */
+function transform(browser) {
+    /**
+     * Transforms the manifest.json file for the given browser.
+     * @param {Buffer} buffer - The buffer to transform.
+     * @returns {string} - The transformed manifest.json file.
+     */
+    return (buffer) => {
+        const manifest = JSON.parse(buffer.toString());
+
+        transformObject(manifest, browser);
+
+        return JSON.stringify(manifest, null, 2);
+    };
+}
+
+const browserKeyPattern = /^__(.+?)__(.+)$/;
+
+/**
+ * Recursively traverses the object and transforms the browser-specific keys.
+ * @param {object} obj - The object to transform.
+ * @param {string} browser - The browser to transform the object for.
+ */
+function transformObject(obj, browser) {
+    if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+        return;
+    }
+
+    const keysToProcess = Object.keys(obj);
+    const keysToAdd = {};
+    const keysToDelete = [];
+
+    for (const key of keysToProcess) {
+        const match = key.match(browserKeyPattern);
+        if (match) {
+            const [, keyBrowser, actualKey] = match;
+            
+            if (keyBrowser === browser) {
+                keysToAdd[actualKey] = obj[key];
+                keysToDelete.push(key);
+            } else {
+                keysToDelete.push(key);
+            }
+        } else {
+            transformObject(obj[key], browser);
+        }
+    }
+
+    for (const [newKey, value] of Object.entries(keysToAdd)) {
+        obj[newKey] = value;
+    }
+    
+    for (const keyToDelete of keysToDelete) {
+        delete obj[keyToDelete];
+    }
+}
+
+module.exports = {
+    transform,
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,10 @@ const BundleAnalyzerPlugin =
   require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
 const CopyPlugin = require("copy-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { transform } = require("./scripts/transform-manifest");
+
+const browser = process.env.BROWSER || "chrome";
+const outputDir = `dist-${browser}-mv3`;
 
 module.exports = {
   module: {
@@ -41,6 +45,7 @@ module.exports = {
   output: {
     filename: "[name].js",
     publicPath: "/",
+    path: path.resolve(__dirname, outputDir),
   },
   mode: "development",
   devServer: {
@@ -64,7 +69,11 @@ module.exports = {
     }),
     new CopyPlugin({
       patterns: [
-        { from: "manifest.json", to: "." },
+        {
+          from: "manifest.template.json",
+          to: "manifest.json",
+          transform: transform(browser),
+        },
         { from: "images", to: "images" },
       ],
     }),


### PR DESCRIPTION
## Summary
Fixes #1066 

This PR implements browser-specific manifest generation to support both Chrome and Firefox with Manifest V3:

- Added manifest template system: Created `manifest.template.json` with browser-specific keys using the pattern `__{browser}__{key}` (e.g., `__chrome__service_worker`, `__firefox__scripts`)
- Implemented manifest transformer: Added `scripts/transform-manifest.js` that processes the template and generates browser-specific manifest files during build
- Updated npm scripts: 
  - Modified webpack config to support browser-specific builds via `BROWSER` environment variable
  - Added separate build scripts for Chrome and Firefox (`build:chrome-mv3`, `build:firefox-mv3`)
   - mv3 means Manifest V3
  - Added `build:all` script to build both browsers
  - Output directories are now browser-specific (`dist-chrome-mv3`, `dist-firefox-mv3`)
- Updated CI: Modified CI workflow to use `build:all` instead of `build`
- Updated .gitignore: Added `/dist-*` pattern to ignore all browser-specific dist directories

## Testing

Verified that the extension successfully fetches pull request lists on the following browsers:
  - Floorp (12.7.0, Firefox 145.0.1)
  - Arc (1.122.0 (71105), Chromium Engine Version 142.0.7444.176)
 
## Notes

`release.yml` is not updated yet because I'm not familiar with the extension deployment process to Chrome Web Store and Firefox Add-ons.

After this PR is merged, please update `release.yml` before releasing the extension.

If helpful, here is a related reference: https://github.com/sun-yryr/prmonitor/commit/89abd46d42e6de8032b884a1101d447a408f04fd