### PR TITLE
fix: chrome.runtime.sendMessage now returns a Promise

### DIFF
--- a/src/messaging/implementation.ts
+++ b/src/messaging/implementation.ts
@@ -7,7 +7,11 @@ export function buildMessenger(chromeApi: ChromeApi): CrossScriptMessenger {
       chromeApi.runtime.onMessage.addListener(callback);
     },
     send(message) {
-      chromeApi.runtime.sendMessage(message);
+      // In manifest v3, sendMessage returns a Promise that rejects if no receiver exists.
+      // We need to catch and ignore this error to prevent uncaught promise rejections.
+      chromeApi.runtime.sendMessage(message).catch((error) => {
+        console.debug("Message send failed", { message, error });
+      });
     },
   };
 }


### PR DESCRIPTION
Fixes #1068 

## Summary

I added a `.catch` block because `chrome.runtime.sendMessage` now returns a Promise.


https://developer.mozilla.org/ja/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage